### PR TITLE
Update tf: dynamic R53 generation and new variables

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,20 +1,26 @@
 # Terraform
 terraform {
-  backend "s3" {
-    bucket = "jamiejohnstone-com-infra"
-    key    = "tf-state"
-    region = "eu-west-2"
-  }
+    backend "s3" {
+        bucket = "jamiejohnstone-com-infra"
+        key    = "tf-state"
+        region = "eu-west-2"
+    }
 }
 
 # Providers
+# Default to London, N Virginia included for ACM
 provider "aws" {
-  region  = "eu-west-2"
+    region  = "eu-west-2"
+}
+
+provider "aws" {
+    region  = "us-east-1"
+    alias = "us-east-1"
 }
 
 # Locals
 locals {
-  s3_origin_id = "S3-jamiejohnstone.com"
+    
 }
 
 # S3 Bucket
@@ -27,7 +33,7 @@ resource "aws_s3_bucket" "s3-jamiejohnstone-com" {
 }
 
 resource "aws_s3_bucket_policy" "s3-jamiejohnstone-com" {
-    bucket = "${aws_s3_bucket.s3-jamiejohnstone-com.id}"
+    bucket = aws_s3_bucket.s3-jamiejohnstone-com.id
     policy = <<POLICY
     {
         "Version": "2012-10-17",
@@ -44,86 +50,93 @@ resource "aws_s3_bucket_policy" "s3-jamiejohnstone-com" {
     POLICY
 }
 
+# CloudFront SSL Certificate
+resource "aws_acm_certificate" "acm-jamiejohnstone-com" {
+    provider = aws.us-east-1
+    domain_name       = "jamiejohnstone.com"
+    validation_method = "DNS"
+
+    subject_alternative_names = var.domains
+
+    tags = {
+        Environment = "Production"
+    }
+    lifecycle {
+        ignore_changes = [ subject_alternative_names, domain_validation_options ]
+    }
+}
+
 # CloudFront Distribution
 resource "aws_cloudfront_distribution" "cf-jamiejohnstone-com" {
-  origin {
-    domain_name = "${aws_s3_bucket.s3-jamiejohnstone-com.bucket_regional_domain_name}"
-    origin_id   = "${local.s3_origin_id}"
-  }
+    origin {
+        domain_name = aws_s3_bucket.s3-jamiejohnstone-com.bucket_regional_domain_name
+        origin_id   = var.s3_origin_id
+    }
 
-    enabled             = true
-    is_ipv6_enabled     = true
-    comment             = "jamiejohnstone.com"
+    enabled = true
+    is_ipv6_enabled = true
+    comment = "jamiejohnstone.com"
     default_root_object = "index.html"
 
-    aliases = [ "www.jamesjohnstone.co",
-                "jamiejohnstone.com",
-                "www.mesj.co",
-                "www.jamiejohnstone.com",
-                "jamesjohnstone.co",
-                "miej.co",
-                "mesj.co",
-                "www.miej.co"
-            ]
+    aliases = var.domains
 
-  default_cache_behavior {
-    target_origin_id = "${local.s3_origin_id}"
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
-    allowed_methods  = ["GET", "HEAD"]
-    cached_methods   = ["GET", "HEAD"]
+    default_cache_behavior {
+        target_origin_id = var.s3_origin_id
+        viewer_protocol_policy = "redirect-to-https"
+        min_ttl                = 0
+        default_ttl            = 86400
+        max_ttl                = 31536000
+        allowed_methods  = ["GET", "HEAD"]
+        cached_methods   = ["GET", "HEAD"]
 
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
-      }
+        forwarded_values {
+            query_string = false
+            cookies {
+                forward = "none"
+            }
+        }
     }
-  }
 
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
+    restrictions {
+        geo_restriction {
+            restriction_type = "none"
+        }
     }
-  }
 
-  price_class = "PriceClass_All"
+    price_class = "PriceClass_All"
 
-  tags = {
-    Environment = "production"
-  }
+    tags = {
+        Environment = "production"
+    }
 
-  viewer_certificate {
-    acm_certificate_arn         = "arn:aws:acm:us-east-1:913976950049:certificate/b72c31a7-21e1-4a16-85d5-17b068ca4bd9"
-    ssl_support_method          = "sni-only"
-    minimum_protocol_version    = "TLSv1.1_2016"
-  }
+    viewer_certificate {
+        acm_certificate_arn         = aws_acm_certificate.acm-jamiejohnstone-com.arn
+        ssl_support_method          = "sni-only"
+        minimum_protocol_version    = "TLSv1.1_2016"
+    }
 }
 
 # Route 53 Record pointing domain and www. at CloudFront
-resource "aws_route53_record" "jamiejohnstone-com-A" {
+resource "aws_route53_record" "r53-jamiejohnstone-com-A" {
     zone_id = "Z4NVW4V8EWN1T"
     name    = "jamiejohnstone.com"
     type    = "A"
 
     alias {
-        name    = "${aws_cloudfront_distribution.cf-jamiejohnstone-com.domain_name}"
-        zone_id = "${aws_cloudfront_distribution.cf-jamiejohnstone-com.hosted_zone_id}"
+        name    = aws_cloudfront_distribution.cf-jamiejohnstone-com.domain_name
+        zone_id = aws_cloudfront_distribution.cf-jamiejohnstone-com.hosted_zone_id
         evaluate_target_health = false
     }
 }
 
-resource "aws_route53_record" "www-jamiejohnstone-com-A" {
+resource "aws_route53_record" "r53-www-jamiejohnstone-com-A" {
     zone_id = "Z4NVW4V8EWN1T"
     name    = "www.jamiejohnstone.com"
     type    = "A"
 
     alias {
-        name    = "${aws_cloudfront_distribution.cf-jamiejohnstone-com.domain_name}"
-        zone_id = "${aws_cloudfront_distribution.cf-jamiejohnstone-com.hosted_zone_id}"
+        name    = aws_cloudfront_distribution.cf-jamiejohnstone-com.domain_name
+        zone_id = aws_cloudfront_distribution.cf-jamiejohnstone-com.hosted_zone_id
         evaluate_target_health = false
     }
 }

--- a/infra/vars.tf
+++ b/infra/vars.tf
@@ -1,19 +1,18 @@
+# Origin Name for S3 in Cloudfront
 variable "s3_origin_id" {
   type = string
   default = "S3-jamiejohnstone.com"
 }
 
+# Domains listed below will generate Route 53 entries (for FQDN and www.), add the name to SSL certs
+# and add as an alias to CloudFront
 variable "domains" {
-    type    = set(string)
+    type = set(string)
     description = "List of domains to generate records for"
     default = [
     "jamesjohnstone.co",
-    "www.jamesjohnstone.co",
     "jamiejohnstone.com",
-    "www.jamiejohnstone.com",
     "mesj.co",
-    "www.mesj.co",
-    "miej.co",
-    "www.miej.co"
+    "miej.co"
     ]
 }

--- a/infra/vars.tf
+++ b/infra/vars.tf
@@ -1,0 +1,19 @@
+variable "s3_origin_id" {
+  type = string
+  default = "S3-jamiejohnstone.com"
+}
+
+variable "domains" {
+    type    = set(string)
+    description = "List of domains to generate records for"
+    default = [
+    "jamesjohnstone.co",
+    "www.jamesjohnstone.co",
+    "jamiejohnstone.com",
+    "www.jamiejohnstone.com",
+    "mesj.co",
+    "www.mesj.co",
+    "miej.co",
+    "www.miej.co"
+    ]
+}


### PR DESCRIPTION
Work to:
- separate variables into a new file (vars.tf)
- update references to variables in main.tf
- make all domain references dynamic, including generation of FQDN and www. R53 records.